### PR TITLE
Update/Remove links

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ depends: [Vault] #If your addon depends on another plugin. See note 2 at the bot
 4. Right click project > `Show In` > `System Explorer` then open the selected directory
 5. In the `bin` directory, you should find the files `code.class` and `info.yml`
 6. Copy both files into a new folder. Optionally add a source file.
-7. If your folder now looks like <a href="https://github.com/ServerSelectorX/Connector-Addons/tree/master/PlayerCount">this</a> you are done!
+7. You're done!
 8. Submit a pull request to this repo so your addon is listed here.
 ## Good to know
 - If you use any methods that are only available in certain versions of Bukkit, please explain in the description of your addon
-- You can use APIs from other plugins, just make sure that you put that plugin as a dependency in your info.yml and as a soft dependency in <a href="https://github.com/ServerSelectorX/ServerSelectorX-Connector/blob/master/src/plugin.yml">SSX connector plugin.yml</a>. If you are using a public plugin please submit a pull request. Otherwise, open the jar using 7-zip and edit plugin.yml.
+- You can use APIs from other plugins, just make sure that you put that plugin as a dependency in your info.yml and as a soft dependency in <a href="https://github.com/ServerSelectorX/ServerSelectorX-Connector/blob/master/resources/plugin.yml">SSX connector plugin.yml</a>. If you are using a public plugin please submit a pull request. Otherwise, open the jar using 7-zip and edit plugin.yml.
 - If you need to do something when your addon is loaded, you can override the method `onLoad()`. The config is loaded before `onLoad()` is called.
 - You can add any listener you want to the class, they are registered automatically. `AddonClass` already implements `Listener`.


### PR DESCRIPTION
You seem to have removed the Player Addon without removing the link in the readme.
Also, the link for the SSX Connector's plugin.yml was wrong too, so I fixed those two mistakes.

From what I can see did your plugin(s) change a lot and the soft dependencies as mentioned in the readme are no longer a thing?